### PR TITLE
adding participantGroup data extraction methods

### DIFF
--- a/R/CreateConnection.R
+++ b/R/CreateConnection.R
@@ -66,9 +66,14 @@ CreateConnection = function(study = NULL, login = NULL, password = NULL, use.dat
     nf <- try(get("labkey.netrc.file", .GlobalEnv), silent = TRUE)
   }
   if(!inherits(nf, "try-error") && !is.null(nf)){
-    curlOptions <- labkey.setCurlOptions(ssl.verifyhost = 2, sslversion = 1, netrc.file = nf, useragent = paste("ImmuneSpaceR", packageVersion("ImmuneSpaceR")))
+    curlOptions <- labkey.setCurlOptions(ssl.verifyhost = 2, 
+                                         sslversion = 1, 
+                                         netrc.file = nf, 
+                                         useragent = paste("ImmuneSpaceR", packageVersion("ImmuneSpaceR")))
   } else{
-    curlOptions <- labkey.setCurlOptions(ssl.verifyhost = 2, sslversion = 1, useragent = paste("ImmuneSpaceR", packageVersion("ImmuneSpaceR")))
+    curlOptions <- labkey.setCurlOptions(ssl.verifyhost = 2, 
+                                         sslversion = 1, 
+                                         useragent = paste("ImmuneSpaceR", packageVersion("ImmuneSpaceR")))
   }
   
   if(length(study) <= 1){
@@ -168,16 +173,20 @@ CreateConnection = function(study = NULL, login = NULL, password = NULL, use.dat
 #' }
 #'@return An instance of an ImmuneSpaceConnection for a study in `labkey.url.path`
 .ISCon <- setRefClass(Class = "ImmuneSpaceConnection",
-            fields = list(study = "character", config = "list",
+            fields = list(study = "character", 
+                          config = "list",
                           available_datasets = "data.table",
-                          data_cache = "list", constants = "list")
+                          data_cache = "list", 
+                          constants = "list")
 )
 
 # Functions used in initialize need to be declared ahead of it
 #' @importFrom gtools mixedsort
 .ISCon$methods(
   checkStudy=function(verbose = FALSE){
-    validStudies <- mixedsort(grep("^SDY", basename(lsFolders(getSession(config$labkey.url.base, "Studies"))), value = TRUE))
+    validStudies <- mixedsort(grep("^SDY", 
+                                   basename(lsFolders(getSession(config$labkey.url.base, "Studies"))), 
+                                   value = TRUE))
     req_study <- basename(config$labkey.url.path)
     if(!req_study %in% c("", validStudies)){
       if(!verbose){

--- a/R/ImmuneSpace.R
+++ b/R/ImmuneSpace.R
@@ -11,34 +11,31 @@
 # Returns TRUE if the connection is at project level ("/Studies")
 .ISCon$methods(
   .isProject=function()
-    if(config$labkey.url.path == "/Studies/"){
-      TRUE
-    } else{
-      FALSE
-    }
+    res <- ifelse(config$labkey.url.path == "/Studies/", TRUE, FALSE)
 )
+
 .ISCon$methods(
   GeneExpressionInputs=function(){
     if(!is.null(data_cache[[constants$matrix_inputs]])){
       data_cache[[constants$matrix_inputs]]
     }else{
-      ge <- data.table(.getLKtbl(con = .self, 
-                                 schema = "assay.Expressionmatrix.matrix",
-                                 query = "InputSamples",
-                                 viewName = "gene_expression_matrices",
-                                 colNameOpt = "fieldname"))
+      ge <- .getLKtbl(con = .self, 
+                      schema = "assay.Expressionmatrix.matrix",
+                      query = "InputSamples",
+                      viewName = "gene_expression_matrices",
+                      colNameOpt = "fieldname")
       setnames(ge,.self$.munge(colnames(ge)))
-      data_cache[[constants$matrix_inputs]]<<-ge
+      data_cache[[constants$matrix_inputs]] <<- ge
     }
   }
 )
-
 
 .ISCon$methods(
   .isRunningLocally=function(path){
     file.exists(path)
   }
 )
+
 .ISCon$methods(
   .localStudyPath=function(urlpath){
     LOCALPATH <- "/share/files/"
@@ -58,6 +55,7 @@
           cat(sprintf("\t%s\n",available_datasets[i,Name]))
         }
       }
+      
       if("expression" %in% which){
         if(!is.null(data_cache[[constants$matrices]])){
           cat("Expression Matrices\n")
@@ -66,8 +64,8 @@
           }
         }
       }
-    })
-
+    }
+)
 
 .ISCon$methods(
     listGEAnalysis = function(){
@@ -101,22 +99,32 @@
     data_cache[grep("^GE", names(data_cache), invert = TRUE)] <<- NULL
   }
 )
+
 .ISCon$methods(
     show=function(){
     "Display information about the object."
       cat(sprintf("Immunespace Connection to study %s\n",study))
-      cat(sprintf("URL: %s\n",file.path(gsub("/$","",config$labkey.url.base),gsub("^/","",config$labkey.url.path))))
+      
+      cat(sprintf("URL: %s\n",
+                  file.path(gsub("/$","",config$labkey.url.base),
+                            gsub("^/","",config$labkey.url.path)))
+          )
+      
       cat(sprintf("User: %s\n",config$labkey.user.email))
+      
       cat("Available datasets\n")
+      
       for(i in 1:nrow(available_datasets)){
         cat(sprintf("\t%s\n",available_datasets[i,Name]))
       }
+      
       if(!is.null(data_cache[[constants$matrices]])){
         cat("Expression Matrices\n")
         for(i in 1:nrow(data_cache[[constants$matrices]])){
           cat(sprintf("\t%s\n",data_cache[[constants$matrices]][i, name]))
         }
       }
+      
     }
 )
 
@@ -334,8 +342,6 @@
                  "date")
     
     filtData <- allData[ , !(colnames(allData) %in% cols2rm) ]
-    
-    return(filtData)
   }
 )
 

--- a/R/getDataset.R
+++ b/R/getDataset.R
@@ -5,8 +5,18 @@
   old <- tolower(curlUnescape(gsub("~.*$", "", colFilter)))
   old[old == "participant_id"] <- "participant id"
   suppressWarnings({
-    labels <- tolower(colnames(labkey.selectRows(lub, lup, schema, query, view, maxRows = 0, colNameOpt = "caption")))
-    names <- colnames(labkey.selectRows(lub, lup, schema, query, view, maxRows = 0, colNameOpt = "fieldname"))
+    labels <- tolower(colnames(.getLKtbl(schema = schema, 
+                                         query = query,
+                                         viewName = view,
+                                         maxRows = 0,
+                                         colNameOpt = "caption",
+                                         showHidden = FALSE)))
+    names <- tolower(colnames(.getLKtbl(schema = schema, 
+                                         query = query,
+                                         viewName = view,
+                                         maxRows = 0,
+                                         colNameOpt = "fieldname",
+                                         showHidden = FALSE)))
   })
   # Get the new names
   idx <- which(old %in% labels)
@@ -73,15 +83,13 @@ filter_cached_copy <- function(filters, data){
         } else{
           cache <- TRUE
         }
-        data <- data.table(
-          labkey.selectRows(baseUrl = config$labkey.url.base,
-                            config$labkey.url.path,
-                            schemaName = "study",
-                            queryName = x,
-                            viewName = viewName,
-                            colNameOpt = "caption",
-                            colFilter = colFilter,
-                            ...))
+        data <- .getLKtbl(schema = "study",
+                          query = x,
+                          viewName = viewName,
+                          colNameOpt = "caption",
+                          colFilter = colFilter,
+                          showHIdden = FALSE,
+                          ...)
         setnames(data, .self$.munge(colnames(data)))
         if(cache){
           data_cache[[cache_name]] <<- data

--- a/R/getDataset.R
+++ b/R/getDataset.R
@@ -6,17 +6,17 @@
   old[old == "participant_id"] <- "participant id"
   
   colFn <- function(colNameOpt){
-    res <- tolower(colnames(.getLKtbl(con = con,
-                                      schema = schema, 
-                                      query = query,
-                                      viewName = view,
-                                      maxRows = 0,
-                                      colNameOpt = colNameOpt,
-                                      showHidden = FALSE)))
+    res <- colnames(.getLKtbl(con = con,
+                              schema = schema, 
+                              query = query,
+                              viewName = view,
+                              maxRows = 0,
+                              colNameOpt = colNameOpt,
+                              showHidden = FALSE))
   }
   
   suppressWarnings({
-    labels <- colFn(colNameOpt = "caption")
+    labels <- tolower(colFn(colNameOpt = "caption"))
     names <- colFn(colNameOpt = "fieldname")
   })
   
@@ -53,7 +53,8 @@ filter_cached_copy <- function(filters, data){
     whether a cached version exist or not.\n
     colFilter: A character. A filter as returned by Rlabkey's makeFilter function.\n
     '...': Extra arguments to be passed to labkey.selectRows."
-    if(nrow(available_datasets[Name%in%x])==0){
+    
+    if( nrow(available_datasets[Name%in%x]) == 0 ){
       wstring <- paste0(study, " has invalid data set: ",x)
       if(config$verbose){
         wstring <- paste0(wstring, "\n",
@@ -61,21 +62,23 @@ filter_cached_copy <- function(filters, data){
                           paste(available_datasets$Name, collapse = ", "), ".")
       }
       stop(wstring)
-    } else{
+      
+    } else {
       cache_name <- paste0(x, ifelse(original_view, "_full", ""))
       nOpts <- length(list(...))
-      if(!is.null(data_cache[[cache_name]]) & !reload & is.null(colFilter) & nOpts == 0){ # Serve cache
+      
+      if( !is.null(data_cache[[cache_name]]) & !reload & is.null(colFilter) & nOpts == 0 ){ # Serve cache
         data <- data_cache[[cache_name]]
         #if(!is.null(colFilter)){
         #  data <- filter_cached_copy(colFilter, data)
         #  return(data)
         #} else{
         #}
-      } else{ # Download the data
+        
+      } else { # Download the data
         viewName <- NULL
-        if(original_view){
-          viewName <- "full"
-        }
+        if(original_view){ viewName <- "full"}
+        
         if(!is.null(colFilter)){
           colFilter <- .check_filter(con = .self, 
                                      schema = "study", 
@@ -88,6 +91,7 @@ filter_cached_copy <- function(filters, data){
         } else{
           cache <- TRUE
         }
+        
         data <- .getLKtbl(con = .self,
                           schema = "study",
                           query = x,
@@ -96,15 +100,15 @@ filter_cached_copy <- function(filters, data){
                           colFilter = colFilter,
                           showHidden = FALSE,
                           ...)
-        
         setnames(data, .self$.munge(colnames(data)))
-        if(cache){
-          data_cache[[cache_name]] <<- data
-        }
+        
+        if( cache ){ data_cache[[cache_name]] <<- data }
       }
-      if(!is.null(config$use.data.frame) & config$use.data.frame){
+      
+      if( !is.null(config$use.data.frame) & config$use.data.frame ){
         data <- data.frame(data)
       }
+      
       return(data)
     }
   })

--- a/R/getGEMatrix.R
+++ b/R/getGEMatrix.R
@@ -87,22 +87,31 @@ NULL
     
     runID <- data_cache$GE_matrices[name == matrix_name, rowid]
     pheno_filter <- makeFilter(c("Run", "EQUAL", runID), 
-                               c("Biosample/biosample_accession", "IN", paste(colnames(matrix), collapse = ";")))
-    pheno <- unique(data.table(labkey.selectRows(
-      config$labkey.url.base, config$labkey.url.path,
-      #"assay.ExpressionMatrix.matrix", "InputSamples", "gene_expression_matrices",
-      "study", "HM_InputSamplesQuerySnapshot",
-      containerFilter = "CurrentAndSubfolders",
-      colNameOpt = "caption", colFilter = pheno_filter)))
+                               c("Biosample/biosample_accession", 
+                                 "IN", 
+                                 paste(colnames(matrix), collapse = ";")))
+
+    pheno <- unique(.getLKtbl(schema = "study",
+                              query = "HM_InputSamplesQuerySnapshot",
+                              containerFilter = "CurrentAndSubfolders",
+                              colNameOpt = "fieldname",
+                              colFilter = pheno_filter,
+                              showHidden = FALSE))
     
     setnames(pheno, .self$.munge(colnames(pheno)))
+    
+    pheno <- data.frame(pheno, stringsAsFactors = F)
 
-    #pheno <- pheno[, list(biosample_accession, ParticipantId, arm_name,
-    pheno <- pheno[, list(biosample_accession, participant_id, cohort,
-                          study_time_collected, study_time_collected_unit)]
+    pheno <- pheno[, which(colnames(pheno) %in% c("biosample_accession", 
+                                                  "participantid", 
+                                                  "cohort",
+                                                  "study_time_collected", 
+                                                  "study_time_collected_unit")) ]
     
     if(summary){
-      fdata <- data.frame(FeatureId = matrix$gene_symbol, gene_symbol = matrix$gene_symbol, row.names = matrix$gene_symbol)
+      fdata <- data.frame(FeatureId = matrix$gene_symbol, 
+                          gene_symbol = matrix$gene_symbol, 
+                          row.names = matrix$gene_symbol)
       rownames(fdata) <- fdata$FeatureId
       fdata <- AnnotatedDataFrame(fdata)
     } else{
@@ -114,6 +123,7 @@ NULL
       rownames(fdata) <- fdata$FeatureId
       fdata <- AnnotatedDataFrame(fdata)
     }
+    
     dups <- colnames(matrix)[duplicated(colnames(matrix))]
     if(length(dups) > 0){
       for(dup in dups){
@@ -127,10 +137,10 @@ NULL
         warning("The matrix contains subjects with multiple measures per timepoint. Averaging expression values.")
       }
     }
+    
     exprs <- as.matrix(matrix[, -1L, with = FALSE])
     exprs <- exprs[, colnames(exprs) %in% pheno$biosample_accession] #At project level, InputSamples may be filtered
 
-    pheno <- data.frame(pheno)
     rownames(pheno) <- pheno$biosample_accession
     pheno <- pheno[colnames(exprs), ]
     ad_pheno <- AnnotatedDataFrame(data = pheno)
@@ -216,22 +226,30 @@ NULL
     } 
     bsFilter <- makeFilter(c("biosample_accession", "IN",
                              paste(pData(data_cache[[x]])$biosample_accession, collapse = ";")))
-    bs2es <- data.table(labkey.selectRows(config$labkey.url.base, config$labkey.url.path,
-                                          "immport", "expsample_2_biosample",
-                                          colFilter = bsFilter, colNameOpt = "rname"))
+    bs2es <- .getLKtbl(schema = "immport",
+                       query = "expsample_2_biosample",
+                       colFilter = bsFilter,
+                       colNameOpt = "rname")
+    
     esFilter <- makeFilter(c("expsample_accession", "IN",
                              paste(bs2es$expsample_accession, collapse = ";")))
-    es2trt <- data.table(labkey.selectRows(config$labkey.url.base, config$labkey.url.path,
-                                           "immport", "expsample_2_treatment",
-                                           colFilter = esFilter, colNameOpt = "rname"))
+    es2trt <- .getLKtbl(schema = "immport",
+                       query = "expsample_2_treatment",
+                       colFilter = esFilter,
+                       colNameOpt = "rname")
+    
     trtFilter <- makeFilter(c("treatment_accession", "IN",
                               paste(es2trt$treatment_accession, collapse = ";")))
-    trt <- data.table(labkey.selectRows(config$labkey.url.base, config$labkey.url.path,
-                                        "immport", "treatment",
-                                        colFilter = trtFilter, colNameOpt = "rname"))
+    trt <- .getLKtbl(schema = "immport",
+                     query = "treatment",
+                     colFilter = trtFilter,
+                     colNameOpt = "rname")
+    
     bs2trt <- merge(bs2es, es2trt, by = "expsample_accession")
     bs2trt <- merge(bs2trt, trt, by = "treatment_accession")
-    pData(data_cache[[x]])$treatment <<- bs2trt[match(pData(data_cache[[x]])$biosample_accession, biosample_accession), name]
+    
+    pData(data_cache[[x]])$treatment <<- bs2trt[match(pData(data_cache[[x]])$biosample_accession, 
+                                                      biosample_accession), name]
     return(data_cache[[x]])
   }
 )
@@ -257,31 +275,48 @@ NULL
     x: An ExpressionSet, as returned by getGEMatrix.\n
     colType: A character. The type of column names. Valid options are 'expsample_accession'
     and 'participant_id'."
+    
     if(is.null(EM) | !is(EM, "ExpressionSet")){
       stop("EM should be a valid ExpressionSet, as returned by getGEMatrix")
     }
+    
     if(!all(grepl("^BS", sampleNames(EM)))){
       stop("All sampleNames should be biosample_accession, as returned by getGEMatrix")
     }
+    
     pd <- data.table(pData(EM))
     colType <- gsub("_.*$", "", tolower(colType))
+    
     if(colType == "expsample"){
       bsFilter <- makeFilter(c("biosample_accession", "IN",
                                  paste(pd$biosample_accession, collapse = ";")))
-      bs2es <- data.table(labkey.selectRows(config$labkey.url.base, config$labkey.url.path,
-                                              "immport", "expsample_2_biosample",
-                                              colFilter = bsFilter, colNameOpt = "rname"))
-      pd <- merge(pd, bs2es[, list(biosample_accession, expsample_accession)], by = "biosample_accession")
-      es <- pd[match(sampleNames(EM), pd$biosample_accession), expsample_accession]
-      sampleNames(EM) <- pData(EM)$expsample_accession <- es
+      bs2es <- .getLKtbl(schema = "immport",
+                         query = "expsample_2_biosample",
+                         colFilter = bsFilter,
+                         colNameOpt = "rname")
+      pd <- merge(pd, 
+                  bs2es[ , list(biosample_accession, expsample_accession)], 
+                  by = "biosample_accession")
+      
+      sampleNames(EM) <- pData(EM)$expsample_accession <- pd[match(sampleNames(EM), 
+                                                                   pd$biosample_accession), 
+                                                             expsample_accession]
+      
     } else if(colType %in% c("participant", "subject")){
-      pd <- pd[, nID := paste0(participant_id, "_", tolower(substr(study_time_collected_unit, 1, 1)), study_time_collected)]
+      pd[, nID := paste0(participant_id, 
+                         "_", 
+                         tolower(substr(study_time_collected_unit, 1, 1)), 
+                         study_time_collected)
+         ]
       sampleNames(EM) <- pd[ match(sampleNames(EM), pd$biosample_accession), nID]
+      
     } else if(colType == "biosample"){
       warning("Nothing done, the column names should already be biosample_accession numbers.")
+      
     } else{
       stop("colType should be one of 'expsample_accession', 'biosample_accession', 'participant_id'.")
     }
+    
     return(EM)
   }
 )

--- a/R/getGEMatrix.R
+++ b/R/getGEMatrix.R
@@ -7,7 +7,7 @@ NULL
   downloadMatrix=function(x, summary = FALSE){
     cache_name <- paste0(x, ifelse(summary, "_sum", ""))
     if(is.null(data_cache[[cache_name]])){
-      if(nrow(subset(data_cache[[constants$matrices]], name%in%x)) == 0){
+      if( nrow(subset(data_cache[[constants$matrices]], name %in% x )) == 0 ){
         stop(sprintf("No matrix %s in study\n", x))
       }
       summary <- ifelse(summary, ".summary", "")
@@ -91,7 +91,8 @@ NULL
                                  "IN", 
                                  paste(colnames(matrix), collapse = ";")))
 
-    pheno <- unique(.getLKtbl(schema = "study",
+    pheno <- unique(.getLKtbl(con = .self,
+                              schema = "study",
                               query = "HM_InputSamplesQuerySnapshot",
                               containerFilter = "CurrentAndSubfolders",
                               colNameOpt = "fieldname",
@@ -226,21 +227,24 @@ NULL
     } 
     bsFilter <- makeFilter(c("biosample_accession", "IN",
                              paste(pData(data_cache[[x]])$biosample_accession, collapse = ";")))
-    bs2es <- .getLKtbl(schema = "immport",
+    bs2es <- .getLKtbl(con = .self,
+                       schema = "immport",
                        query = "expsample_2_biosample",
                        colFilter = bsFilter,
                        colNameOpt = "rname")
     
     esFilter <- makeFilter(c("expsample_accession", "IN",
                              paste(bs2es$expsample_accession, collapse = ";")))
-    es2trt <- .getLKtbl(schema = "immport",
-                       query = "expsample_2_treatment",
-                       colFilter = esFilter,
-                       colNameOpt = "rname")
+    es2trt <- .getLKtbl(con = .self,
+                        schema = "immport",
+                        query = "expsample_2_treatment",
+                        colFilter = esFilter,
+                        colNameOpt = "rname")
     
     trtFilter <- makeFilter(c("treatment_accession", "IN",
                               paste(es2trt$treatment_accession, collapse = ";")))
-    trt <- .getLKtbl(schema = "immport",
+    trt <- .getLKtbl(con = .self,
+                     schema = "immport",
                      query = "treatment",
                      colFilter = trtFilter,
                      colNameOpt = "rname")
@@ -290,7 +294,8 @@ NULL
     if(colType == "expsample"){
       bsFilter <- makeFilter(c("biosample_accession", "IN",
                                  paste(pd$biosample_accession, collapse = ";")))
-      bs2es <- .getLKtbl(schema = "immport",
+      bs2es <- .getLKtbl(con = .self,
+                         schema = "immport",
                          query = "expsample_2_biosample",
                          colFilter = bsFilter,
                          colNameOpt = "rname")


### PR DESCRIPTION
This merge adds two methods, one to list the participant groups (all, not just the users own) and then get certain data types for those participants.  Feedback on making the code cleaner / handle edge cases / etc is welcome.  I did comment out a method I had written with dplyr to pull in the number of subjects for each participant group ... I thought I remembered that we didn't use dplyr elsewhere in ISR and wanted to keep it out.  However if we want to use it or do similar functionality with other system (e.g. data.table). I can do that.