### PR TITLE
Update getGEMatrix to used cached esets when combining multiple matrices

### DIFF
--- a/R/ISCon-geneExpression.R
+++ b/R/ISCon-geneExpression.R
@@ -40,6 +40,7 @@ ISCon$set(
       } else {
         # adding cols to allow for getGEMatrix() to update
         ge[, annotation := ""][, outputType := ""][] # see data.table #869
+        ge[, cacheinfo := ""][]
         setnames(ge, private$.munge(colnames(ge)))
 
         # adding cohort_type for use with getGEMatrix(cohort)
@@ -134,7 +135,7 @@ ISCon$set(
 
     # Get matrix or matrices
     esetNames <- vapply(matrixName, function(name) {
-      esetName <- paste0(.setCacheName(name, outputType, annotation), "_eset")
+      esetName <- .getEsetName(name, outputType, annotation)
 
       if (esetName %in% names(self$cache) & !reload) {
         message(paste0("returning ", esetName, " from cache"))
@@ -143,6 +144,15 @@ ISCon$set(
         private$.downloadMatrix(name, outputType, annotation, reload)
         private$.getGEFeatures(name, outputType, annotation, reload)
         private$.constructExpressionSet(name, outputType, annotation)
+
+        # Add to cacheinfo
+        cacheinfo_status <- self$cache$GE_matrices$cacheinfo[self$cache$GE_matrices$name == name]
+        cacheinfo <- .getcacheinfo(outputType, annotation)
+        if (!grepl(cacheinfo, cacheinfo_status)) {
+          self$cache$GE_matrices$cacheinfo[self$cache$GE_matrices$name == name] <-
+            paste0(cacheinfo_status,
+                   cacheinfo, ";")
+        }
       }
       return(esetName)
     },
@@ -376,7 +386,7 @@ ISCon$set(
         biosample_accession
       ),
       name
-    ]
+      ]
 
     expressionSet
   }
@@ -427,7 +437,7 @@ ISCon$set(
         pd[
           match(sampleNames(EM), pd$biosample_accession),
           expsample_accession
-        ]
+          ]
     } else if (colType %in% c("participant", "subject")) {
       pd[, nID := paste0(
         participant_id,
@@ -460,7 +470,9 @@ ISCon$set(
                    outputType = "summary",
                    annotation = "latest",
                    reload = FALSE) {
-    cache_name <- .setCacheName(matrixName, outputType, annotation)
+
+    cache_name <- .getMatrixCacheName(matrixName, outputType, annotation)
+    cacheinfo <- .getcacheinfo(outputType, annotation)
 
     # check if study has matrices
     if (nrow(subset(
@@ -472,10 +484,23 @@ ISCon$set(
 
     # check if data in cache corresponds to current request
     # if it does, then no download needed.
-    status <- self$cache$GE_matrices$outputtype[self$cache$GE_matrices$name == matrixName]
-    if (status == outputType & reload != TRUE) {
-      message(paste0("returning ", outputType, " matrix from cache"))
-      return()
+    # Only use matrix from cache when
+    #   a. outputType and annotation match cache OR
+    #   b. outputType matches cache and is not summary
+    # Otherwise, load a new matrix
+    if (!reload) {
+
+      if (grepl(cacheinfo, self$cache$GE_matrices$cacheinfo[self$cache$GE_matrices$name == matrixName]) ) {
+        message(paste0("returning ", outputType, " matrix from cache"))
+        return()
+      }
+      if (outputType != "summary") {
+        if (grepl(outputType, self$cache$GE_matrices$cacheinfo[self$cache$GE_matrices$name == matrixName])) {
+          message(paste0("returning ", outputType, " matrix from cache"))
+          return()
+        }
+      }
+
     }
 
     if (annotation == "ImmSig") {
@@ -583,8 +608,6 @@ ISCon$set(
       file.remove(fl)
     }
 
-    # Be sure to note which output is already in cache. Colnames are "munged"
-    self$cache$GE_matrices$outputtype[self$cache$GE_matrices$name == matrixName] <- outputType
   }
 )
 
@@ -597,15 +620,16 @@ ISCon$set(
                    outputType = "summary",
                    annotation = "latest",
                    reload = FALSE) {
-    cache_name <- .setCacheName(matrixName, outputType, annotation)
+
+    cacheinfo <- .getcacheinfo(outputType, annotation)
+    cache_name <- paste0(matrixName, cacheinfo)
 
     if (!(matrixName %in% self$cache[[private$.constants$matrices]]$name)) {
       stop("Invalid gene expression matrix name")
     }
 
-    status <- self$cache$GE_matrices$annotation[self$cache$GE_matrices$name == matrixName]
-    currOut <- self$cache$GE_matrices$outputtype[self$cache$GE_matrices$name == matrixName]
-    if (status == annotation & reload != TRUE & currOut == outputType) {
+    cacheinfo_status <- self$cache$GE_matrices$cacheinfo[self$cache$GE_matrices$name == matrixName]
+    if (grepl(cacheinfo, cacheinfo_status) & !reload) {
       message(paste0("returning ", annotation, " annotation from cache"))
       return()
     }
@@ -679,8 +703,6 @@ ISCon$set(
     # update cache$gematrices with correct fasId
     self$cache$GE_matrices$featureset[self$cache$GE_matrices$name == matrixName] <- annoSetId
 
-    # Change ge_matrices$annotation
-    self$cache$GE_matrices$annotation[self$cache$GE_matrices$name == matrixName] <- annotation
 
     # push features to cache
     self$cache[[paste0("featureset_", annoSetId)]] <- features
@@ -693,8 +715,9 @@ ISCon$set(
   which = "private",
   name = ".constructExpressionSet",
   value = function(matrixName, outputType, annotation) {
-    cache_name <- .setCacheName(matrixName, outputType, annotation)
-    esetName <- paste0(cache_name, "_eset")
+
+    cache_name <- .getMatrixCacheName(matrixName, outputType, annotation)
+    esetName <- .getEsetName(matrixName, outputType, annotation)
 
     # expression matrix
     message("Constructing ExpressionSet")
@@ -787,7 +810,6 @@ ISCon$set(
     } else {
       annoSetId <- self$cache$GE_matrices$featureset[self$cache$GE_matrices$name == matrixName]
       features <- self$cache[[paste0("featureset_", annoSetId)]][, c("FeatureId", "gene_symbol")]
-
       # IS1 matrices have not been standardized, otherwise all others should be 'feature_id'
       colnames(matrix)[[grep("feature_id|X|V1", colnames(matrix))]] <- "FeatureId"
 
@@ -830,7 +852,7 @@ ISCon$set(
       query = "FeatureAnnotationSet"
     )
     gemx <- self$cache$GE_matrices
-    fasId <- gemx$featureset[ gemx$name == matrixName & gemx$outputtype == outputType ]
+    fasId <- gemx$featureset[ gemx$name == matrixName ]
     fasInfo <- fasInfo[ match(fasId, fasInfo$`Row Id`)]
     isRNA <- (fasInfo$Vendor == "NA" & !grepl("ImmSig", fasInfo$Name)) | grepl("SDY67", fasInfo$Name)
     if (fasInfo$Comment == "Do not update" | is.na(fasInfo$Comment)) {
@@ -880,7 +902,8 @@ ISCon$set(
 # HELPER -----------------------------------------------------------------------
 
 # Set the cache name of expression matrix by output type
-.setCacheName <- function(matrixName, outputType, annotation) {
+.getMatrixCacheName <- function(matrixName, outputType, annotation) {
+
   outputSuffix <- switch(
     outputType,
     "summary" = "_sum",
@@ -894,9 +917,25 @@ ISCon$set(
     "ImmSig" = "_immsig"
   )
 
-  paste0(matrixName, outputSuffix, annotationSuffix)
+
+  if (annotation == "ImmSig" || outputType == "summary") {
+    matrixName <- paste0(matrixName, outputSuffix, annotationSuffix)
+  } else {
+    matrixName <- paste0(matrixName, outputSuffix)
+  }
+  return(matrixName)
+
 }
 
+.getEsetName <- function(matrixName, outputType, annotation) {
+  esetName <- paste0(matrixName, "_", outputType, "_", annotation, "_eset")
+  return(esetName)
+}
+
+.getcacheinfo <- function(outputType, annotation) {
+  cacheinfo <- paste0(outputType, "_", annotation)
+  return(cacheinfo)
+}
 
 # Combine EMs and output only genes available in all EMs.
 .combineEMs <- function(EMlist) {

--- a/R/ISCon-geneExpression.R
+++ b/R/ISCon-geneExpression.R
@@ -133,17 +133,16 @@ ISCon$set(
 
 
     # Get matrix or matrices
-    esetNames <- vapply(matrixName, function(matrixName) {
-      cache_name <- .setCacheName(matrixName, outputType)
-      esetName <- paste0(cache_name, "_eset")
+    esetNames <- vapply(matrixName, function(name) {
+      esetName <- paste0(.setCacheName(name, outputType, annotation), "_eset")
 
       if (esetName %in% names(self$cache) & !reload) {
         message(paste0("returning ", esetName, " from cache"))
       } else {
         self$cache[[esetName]] <- NULL
-        private$.downloadMatrix(matrixName, outputType, annotation, reload)
-        private$.getGEFeatures(matrixName, outputType, annotation, reload)
-        private$.constructExpressionSet(matrixName, outputType, annotation)
+        private$.downloadMatrix(name, outputType, annotation, reload)
+        private$.getGEFeatures(name, outputType, annotation, reload)
+        private$.constructExpressionSet(name, outputType, annotation)
       }
       return(esetName)
     },
@@ -458,10 +457,10 @@ ISCon$set(
   which = "private",
   name = ".downloadMatrix",
   value = function(matrixName,
-                     outputType = "summary",
-                     annotation = "latest",
-                     reload = FALSE) {
-    cache_name <- .setCacheName(matrixName, outputType)
+                   outputType = "summary",
+                   annotation = "latest",
+                   reload = FALSE) {
+    cache_name <- .setCacheName(matrixName, outputType, annotation)
 
     # check if study has matrices
     if (nrow(subset(
@@ -595,10 +594,10 @@ ISCon$set(
   which = "private",
   name = ".getGEFeatures",
   value = function(matrixName,
-                     outputType = "summary",
-                     annotation = "latest",
-                     reload = FALSE) {
-    cache_name <- .setCacheName(matrixName, outputType)
+                   outputType = "summary",
+                   annotation = "latest",
+                   reload = FALSE) {
+    cache_name <- .setCacheName(matrixName, outputType, annotation)
 
     if (!(matrixName %in% self$cache[[private$.constants$matrices]]$name)) {
       stop("Invalid gene expression matrix name")
@@ -694,7 +693,7 @@ ISCon$set(
   which = "private",
   name = ".constructExpressionSet",
   value = function(matrixName, outputType, annotation) {
-    cache_name <- .setCacheName(matrixName, outputType)
+    cache_name <- .setCacheName(matrixName, outputType, annotation)
     esetName <- paste0(cache_name, "_eset")
 
     # expression matrix
@@ -881,15 +880,21 @@ ISCon$set(
 # HELPER -----------------------------------------------------------------------
 
 # Set the cache name of expression matrix by output type
-.setCacheName <- function(matrixName, outputType) {
+.setCacheName <- function(matrixName, outputType, annotation) {
   outputSuffix <- switch(
     outputType,
     "summary" = "_sum",
     "normalized" = "_norm",
     "raw" = "_raw"
   )
+  annotationSuffix <- switch(
+    annotation,
+    "latest" = "_latest",
+    "default" = "_default",
+    "ImmSig" = "_immsig"
+  )
 
-  paste0(matrixName, outputSuffix)
+  paste0(matrixName, outputSuffix, annotationSuffix)
 }
 
 
@@ -913,3 +918,4 @@ ISCon$set(
 
   Reduce(f = combine, EMlist)
 }
+

--- a/R/ISCon-geneExpression.R
+++ b/R/ISCon-geneExpression.R
@@ -67,25 +67,18 @@ ISCon$set(
       # Get matrices from participantIDs
       # Use assay.ExpressionMatrix.inputSamples in executeSQL to get distinct matrices
 
+      sql <- paste0("SELECT DISTINCT Run.Name
+                     FROM InputSamples
+                     WHERE Biosample.participantId IN ('", paste0(participantIds, collapse = "','"), "')"
+      )
+
       matrixNames <- Rlabkey::labkey.executeSql(self$config$labkey.url.base,
-                                 folderPath = self$config$labkey.url.path,
-                                 schemaName = "assay.ExpressionMatrix.matrix",
-                                 sql = paste0("
-                                   SELECT DISTINCT matrix
-                                   FROM InputSamples
-                                     LEFT OUTER JOIN (
-                                        SELECT RowId, Name as matrix FROM assay.ExpressionMatrix.matrix.Runs
-                                     ) R
-                                     ON InputSamples.Run = R.RowId
-                                     LEFT OUTER JOIN (
-                                        SELECT biosample_accession, subject_accession || '.' || regexp_replace(study_accession, 'SDY', '') as participant_id from immport.biosample
-                                     ) B
-                                     ON InputSamples.Biosample = B.biosample_accession
-                                   WHERE participant_id IN ('", paste0(participantIds, collapse = "','"), "')
-                                   "
-                                 ),
-                                 containerFilter = "CurrentAndSubfolders",
-                                 colNameOpt = "fieldname")
+                                                folderPath = self$config$labkey.url.path,
+                                                schemaName = "assay.ExpressionMatrix.matrix",
+                                                sql = sql,
+                                                containerFilter = "CurrentAndSubfolders",
+                                                colNameOpt = "fieldname")
+
       return(self$cache[[private$.constants$matrices]][name %in% matrixNames$matrix])
     }
   }

--- a/R/ISCon-geneExpression.R
+++ b/R/ISCon-geneExpression.R
@@ -79,7 +79,7 @@ ISCon$set(
                                                 containerFilter = "CurrentAndSubfolders",
                                                 colNameOpt = "fieldname")
 
-      return(self$cache[[private$.constants$matrices]][name %in% matrixNames$matrix])
+      return(self$cache[[private$.constants$matrices]][name %in% matrixNames$Name])
     }
   }
 )

--- a/R/ISCon-participantGroup.R
+++ b/R/ISCon-participantGroup.R
@@ -64,6 +64,85 @@ ISCon$set(
   name = "getParticipantData",
   value = function(group, dataType, original_view = FALSE, reload = FALSE, colFilter = NULL, transformMethod = "none", ...) {
     private$.assertAllStudyConnection()
+    groupName <- private$.checkParticipantGroup(group)
+
+    colFilter <- rbind(
+      colFilter,
+      makeFilter(
+        c(paste0("ParticipantId/", groupName), "EQUAL", groupName)
+      )
+    )
+
+      return (self$getDataset(
+        dataType,
+        original_view = original_view,
+        reload = reload,
+        colFilter = colFilter,
+        transformMethod = transformMethod,
+        ...
+      ))
+
+  }
+)
+
+ISCon$set(
+  which = "public",
+  name = "listParticipantGEMatrices",
+  value = function(group, verbose = FALSE) {
+    private$.assertAllStudyConnection()
+    groupName <- private$.checkParticipantGroup(group)
+
+    participantIds <- private$.getParticipantIdsFromGroup(groupName)
+    matrices <- self$listGEMatrices(verbose = verbose, participantIds = participantIds)
+
+    return(matrices)
+
+  })
+
+
+ISCon$set(
+  which = "public",
+  name = "getParticipantGEMatrix",
+  value = function(group, outputType = "summary", annotation = "latest", reload = FALSE) {
+    private$.assertAllStudyConnection()
+    groupName <- private$.checkParticipantGroup(group)
+
+    ids <- private$.getParticipantIdsFromGroup(groupName)
+    matNames <- self$listParticipantGEMatrices(groupName)$name
+
+    message(paste0(length(matNames), " matrices found for ", groupName))
+
+    mat <- self$getGEMatrix(matNames,
+                            outputType = outputType,
+                            annotation = annotation,
+                            reload = reload)
+
+    return(mat[, mat$participant_id %in% ids])
+
+  }
+)
+
+
+
+# PRIVATE ----------------------------------------------------------------------
+# Check if all study connection
+ISCon$set(
+  which = "private",
+  name = ".assertAllStudyConnection",
+  value = function() {
+    if (!identical(self$config$labkey.url.path, "/Studies/")) {
+      stop(
+        "This method only works with connection to all studies. ",
+        'Create a connection to all studies by `con <- CreateConnection("")`'
+      )
+    }
+  }
+)
+
+ISCon$set(
+  which = "private",
+  name = ".checkParticipantGroup",
+  value = function(group) {
 
     # Must rerun this to ensure valid groups are only for that user and are not
     # changed within cache.
@@ -91,77 +170,75 @@ ISCon$set(
         "\n Call `listParticipantGroups()` to see the available groups."
       )
     }
-
-    colFilter <- rbind(
-      colFilter,
-      makeFilter(
-        c(paste0("ParticipantId/", groupName), "EQUAL", groupName)
-      )
-    )
-
-      return (self$getDataset(
-        dataType,
-        original_view = original_view,
-        reload = reload,
-        colFilter = colFilter,
-        transformMethod = transformMethod,
-        ...
-      ))
-
-
-
+    return(groupName)
   }
 )
 
-ISCon$set(
-  which = "public",
-  name = "getParticipantGEMatrix",
-  value = function(group, outputType = "summary", annotation = "latest", reload = FALSE) {
-    private$.assertAllStudyConnection()
-
-
-    cohort_membership <- self$getParticipantData(group,
-                                                 "cohort_membership",
-                                                 colSelect = c("name", "study_accession", "ParticipantId"))
-
-    # Get gem names for those cohorts
-    folderFilter <- makeFilter(
-      c("Folder/Name", "IN", paste0(unique(cohort_membership$study_accession), collapse = ";") )
-    )
-    runs <- labkey.selectRows(self$config$labkey.url.base,
-                              "Studies",
-                              "assay.ExpressionMatrix.matrix",
-                              "Runs",
-                              colFilter = folderFilter)
-    all <- merge(runs, unique(cohort_membership[, .(study_accession, name)]),
-                 by.x = c("Cohort", "Study"), by.y = c("name", "study_accession"),
-                 all.x = FALSE,
-                 all.y = FALSE)
-    mats <- unique(all$Name)
-    message(paste0(length(mats), " matrices found for ", group))
-    mat <- self$getGEMatrix(mats,
-                            outputType = outputType,
-                            annotation = annotation,
-                            reload = reload)
-    return(mat)
-
-  }
-)
-
-
-
-# PRIVATE ----------------------------------------------------------------------
-# Check if all study connection
+# Return a vector of participantIDs for a group
 ISCon$set(
   which = "private",
-  name = ".assertAllStudyConnection",
-  value = function() {
-    if (!identical(self$config$labkey.url.path, "/Studies/")) {
+  name = ".getParticipantIdsFromGroup",
+  value = function(group) {
+    private$.assertAllStudyConnection()
+
+    # ---- Get groups and associated participantIDs ----
+    participantGroupApi <- paste0(
+      self$config$labkey.url.base,
+      "/participant-group",
+      "/Studies",
+      "/browseParticipantGroups.api?",
+      "distinctCatgories=false&",
+      "type=participantGroup&",
+      "includeUnassigned=false&",
+      "includeParticipantIds=false"
+    )
+    # execute via Rlabkey's standard GET function
+    response <- Rlabkey:::labkey.get(participantGroupApi)
+
+    # parse JSON response via jsonlite's fromJSON parsing function
+    parsed <- jsonlite::fromJSON(response, simplifyDataFrame = FALSE)
+
+    # Transform parsed json into a data.table with a row for each group
+    # and a column containing a vector of relevant subjectids
+    groupsList <- lapply(parsed$groups, function(group) {
+      data.table(
+        group_id = group$id,
+        group_name = group$label,
+        subjects = list(group$category$participantIds)
+      )
+    })
+    validGroups <- rbindlist(groupsList)
+
+
+    # ---- Get groupName ----
+
+    if (is.numeric(group)) {
+      col <- "group_id"
+      groupName <- validGroups$group_name[validGroups$group_id == group]
+    } else if (is.character(group)) {
+      col <- "group_name"
+      groupName <- group
+    } else {
       stop(
-        "This method only works with connection to all studies. ",
-        'Create a connection to all studies by `con <- CreateConnection("")`'
+        "`group` should be a number or string. ",
+        "Try again with valid `group`.",
+        "\n Call `listParticipantGroups()` to see the available groups."
       )
     }
+
+    if (!(group %in% validGroups[[col]])) {
+      stop(
+        "'", group, "' is not in the set of `", col,
+        "` created by the current user",
+        " on ", self$config$labkey.url.base,
+        "\n Call `listParticipantGroups()` to see the available groups."
+      )
+    }
+
+    # ---- Return participantIds ----
+
+    return(validGroups[group_name == groupName, subjects][[1]])
+
   }
 )
 

--- a/R/ISCon.R
+++ b/R/ISCon.R
@@ -8,6 +8,7 @@
 #' listGEMatrices
 #' listGEAnalysis
 #' listParticipantGroups
+#' listParticipantMatrices
 #' listWorkspaces
 #' listGatingSets
 #' summarizeCyto
@@ -19,6 +20,7 @@
 #' getGEFiles
 #' getGEInputs
 #' getParticipantData
+#' getParticipantGEMatrix
 #' addTreatmentt
 #' mapSampleNames
 #'
@@ -77,7 +79,7 @@
 #'   \item{\code{listDatasets(output = c("datasets", "expression"))}}{
 #'     Lists the datasets available in the study or studies of the connection.
 #'   }
-#'   \item{\code{listGEMatrices(verbose = FALSE, reload = FALSE)}}{
+#'   \item{\code{listGEMatrices(verbose = FALSE, reload = FALSE, participantIds = NULL)}}{
 #'     Lists available gene expression matrices for the connection.
 #'
 #'     \code{verbose}: A logical. If TRUE, whether to print the extra details
@@ -85,12 +87,27 @@
 #'
 #'     \code{reload}: A logical. If TRUE, retrieve the table of available gene
 #'     expression matrices whether a cached version exist or not.
+#'
+#'     \code{participantIds}: A character vector of participant ids to filter
+#'     by. Only matrices with data from \code{participantIds} will be returned.
+#'     If \code{NULL}, all matrices are returned.
 #'   }
 #'   \item{\code{listGEAnalysis()}}{
 #'     Lists available gene expression analysis for the connection.
 #'   }
 #'   \item{\code{listParticipantGroups()}}{
 #'     Lists available participant groups on the ImmuneSpace portal.
+#'   }
+#'   \item{\code{listParticipantGEMatrices(group, verbose = FALSE)}}{
+#'     Lists available gene expression matrices for participants in \code{group}.
+#'
+#'     \code{group}: A character or integer.
+#'     Call \code{con$listParticipantGroups()} to see available participants
+#'     groups. Use group_id or group_name as input.
+#'
+#'     \code{verbose}: A logical. If TRUE, whether to print the extra details
+#'     for troubleshooting.
+#'
 #'   }
 #'   \item{\code{listWorkspaces(reload = FALSE)}}{
 #'     Lists available workspaces for the connection.
@@ -166,7 +183,7 @@
 #'     meta-study's manuscript was created.
 #'
 #'     \code{reload}: A logical. If set to TRUE, the matrix will be downloaded
-#'     again, even if a cached cop exist in the ImmuneSpaceConnection object.
+#'     again, even if a cached copy exists in the ImmuneSpaceConnection object.
 #'
 #'     \code{verbose}: A logical. If set to TRUE, notes on how the expressionSet
 #'     object was created will be printed, including normalization, summarization,
@@ -190,6 +207,33 @@
 #'
 #'     \code{dataType}: A character. Use \code{con$availableDatasets} to see
 #'     available dataset names.
+#'   }
+#'   \item{\code{getParticipantGEMatrix(group, outputType = "summary",
+#'   annotation = "latest", reload = FALSE)}}{
+#'     Downloads probe-level or gene-symbol summarized expression matrices for all
+#'     participants within \code{group} from ImmuneSpace and constructs an
+#'     ExpressionSet containing observations for each participant in \code{group}
+#'     where gene expression data is available.
+#'
+#'     \code{group}: A character or integer.
+#'     Call \code{con$listParticipantGroups()} to see available participants
+#'     groups. Use group_id or group_name as input.
+#'
+#'     \code{outputType}: A character. one of 'raw', 'normalized' or 'summary'.
+#'     If 'raw', returns an expression matrix of non-normalized values by probe.
+#'     'normalized' returns normalized values by probe. 'summary' returns
+#'     normalized values averaged by gene symbol.
+#'
+#'     \code{annotation}: A character. one of 'default', 'latest', or 'ImmSig'.
+#'     Determines which feature annotation set (FAS) is used. 'default' uses the
+#'     FAS from when the matrix was generated. latest' uses a recently updated
+#'     FAS based on the original. 'ImmSig' is specific to studies involved in
+#'     the ImmuneSignatures project and uses the annotation from when the
+#'     meta-study's manuscript was created.
+#'
+#'     \code{reload}: A logical. If set to TRUE, matrices will be downloaded
+#'     again, even if a cached copy exists in the ImmuneSpaceConnection object.
+#'
 #'   }
 #'   \item{\code{downloadGEFiles(files, destdir = ".")}}{
 #'     Downloads gene expression raw data files.

--- a/man/ImmuneSpaceConnection.Rd
+++ b/man/ImmuneSpaceConnection.Rd
@@ -8,6 +8,7 @@
 \alias{listGEMatrices}
 \alias{listGEAnalysis}
 \alias{listParticipantGroups}
+\alias{listParticipantMatrices}
 \alias{listWorkspaces}
 \alias{listGatingSets}
 \alias{summarizeCyto}
@@ -19,6 +20,7 @@
 \alias{getGEFiles}
 \alias{getGEInputs}
 \alias{getParticipantData}
+\alias{getParticipantGEMatrix}
 \alias{addTreatmentt}
 \alias{mapSampleNames}
 \title{The ImmuneSpaceConnection class}
@@ -87,7 +89,7 @@ study.
   \item{\code{listDatasets(output = c("datasets", "expression"))}}{
     Lists the datasets available in the study or studies of the connection.
   }
-  \item{\code{listGEMatrices(verbose = FALSE, reload = FALSE)}}{
+  \item{\code{listGEMatrices(verbose = FALSE, reload = FALSE, participantIds = NULL)}}{
     Lists available gene expression matrices for the connection.
 
     \code{verbose}: A logical. If TRUE, whether to print the extra details
@@ -95,12 +97,27 @@ study.
 
     \code{reload}: A logical. If TRUE, retrieve the table of available gene
     expression matrices whether a cached version exist or not.
+
+    \code{participantIds}: A character vector of participant ids to filter
+    by. Only matrices with data from \code{participantIds} will be returned.
+    If \code{NULL}, all matrices are returned.
   }
   \item{\code{listGEAnalysis()}}{
     Lists available gene expression analysis for the connection.
   }
   \item{\code{listParticipantGroups()}}{
     Lists available participant groups on the ImmuneSpace portal.
+  }
+  \item{\code{listParticipantGEMatrices(group, verbose = FALSE)}}{
+    Lists available gene expression matrices for participants in \code{group}.
+
+    \code{group}: A character or integer.
+    Call \code{con$listParticipantGroups()} to see available participants
+    groups. Use group_id or group_name as input.
+
+    \code{verbose}: A logical. If TRUE, whether to print the extra details
+    for troubleshooting.
+
   }
   \item{\code{listWorkspaces(reload = FALSE)}}{
     Lists available workspaces for the connection.
@@ -176,7 +193,7 @@ study.
     meta-study's manuscript was created.
 
     \code{reload}: A logical. If set to TRUE, the matrix will be downloaded
-    again, even if a cached cop exist in the ImmuneSpaceConnection object.
+    again, even if a cached copy exists in the ImmuneSpaceConnection object.
 
     \code{verbose}: A logical. If set to TRUE, notes on how the expressionSet
     object was created will be printed, including normalization, summarization,
@@ -200,6 +217,33 @@ study.
 
     \code{dataType}: A character. Use \code{con$availableDatasets} to see
     available dataset names.
+  }
+  \item{\code{getParticipantGEMatrix(group, outputType = "summary",
+  annotation = "latest", reload = FALSE)}}{
+    Downloads probe-level or gene-symbol summarized expression matrices for all
+    participants within \code{group} from ImmuneSpace and constructs an
+    ExpressionSet containing observations for each participant in \code{group}
+    where gene expression data is available.
+
+    \code{group}: A character or integer.
+    Call \code{con$listParticipantGroups()} to see available participants
+    groups. Use group_id or group_name as input.
+
+    \code{outputType}: A character. one of 'raw', 'normalized' or 'summary'.
+    If 'raw', returns an expression matrix of non-normalized values by probe.
+    'normalized' returns normalized values by probe. 'summary' returns
+    normalized values averaged by gene symbol.
+
+    \code{annotation}: A character. one of 'default', 'latest', or 'ImmSig'.
+    Determines which feature annotation set (FAS) is used. 'default' uses the
+    FAS from when the matrix was generated. latest' uses a recently updated
+    FAS based on the original. 'ImmSig' is specific to studies involved in
+    the ImmuneSignatures project and uses the annotation from when the
+    meta-study's manuscript was created.
+
+    \code{reload}: A logical. If set to TRUE, matrices will be downloaded
+    again, even if a cached copy exists in the ImmuneSpaceConnection object.
+
   }
   \item{\code{downloadGEFiles(files, destdir = ".")}}{
     Downloads gene expression raw data files.

--- a/tests/testthat/helper-getParticipantData.R
+++ b/tests/testthat/helper-getParticipantData.R
@@ -12,3 +12,4 @@ test_getParticipantData <- function(dataset, original_view = FALSE) {
     expect_named(data, columns)
   })
 }
+

--- a/tests/testthat/test-getGEMatrix.R
+++ b/tests/testthat/test-getGEMatrix.R
@@ -2,7 +2,7 @@ context("ISCon$getGEMatrix()")
 
 # CreateConnection ------------------------------------------
 
-sdy <- CreateConnection("")
+sdy <- CONNECTIONS$ALL
 IS1 <- CreateConnection("IS1")
 
 

--- a/tests/testthat/test-getGEMatrix.R
+++ b/tests/testthat/test-getGEMatrix.R
@@ -69,11 +69,18 @@ test_that("get_multiple matrices summary without cache error", {
 
 test_that("get_multiple matrices summary with reload", {
   EM <- sdy$getGEMatrix(c("SDY269_PBMC_TIV_Geo", "SDY269_PBMC_LAIV_Geo"),
-    outputType = "summary",
-    annotation = "latest",
-    reload = TRUE
+                        outputType = "summary",
+                        annotation = "latest",
+                        reload = TRUE
   )
   test_EM(EM, summary = TRUE)
+})
+
+test_that("get multiple matrices summary from different studies", {
+  EM <- sdy$getGEMatrix(c("SDY269_PBMC_TIV_Geo", "SDY180_WholeBlood_Grp2Pneunomax23_Geo"), outputType = "summary", annotation = "latest")
+  test_EM(EM, summary = TRUE)
+  expect_equal(ncol(Biobase::exprs(EM)), 193)
+  expect_equal(nrow(Biobase::exprs(EM)), 15476)
 })
 
 # Use specific tests here to ensure the IS1 report will load correctly

--- a/tests/testthat/test-getGEMatrix.R
+++ b/tests/testthat/test-getGEMatrix.R
@@ -19,7 +19,7 @@ test_EM <- function(EM, summary) {
   expect_gt(nrow(Biobase::exprs(EM)), 0)
   if (summary == TRUE) {
     # In summary, no gene is NA
-    expect_false(any(is.na(fData(EM)$gene_symbol)))
+    expect_false(any(is.na(Biobase::fData(EM)$gene_symbol)))
   }
 }
 
@@ -78,23 +78,30 @@ test_that("get_multiple matrices summary with reload", {
 })
 
 test_that("get multiple matrices summary from different studies", {
-  EM <- sdy$getGEMatrix(c("SDY269_PBMC_TIV_Geo", "SDY180_WholeBlood_Grp2Pneunomax23_Geo"), outputType = "summary", annotation = "latest")
+  EM <- sdy$getGEMatrix(c("SDY269_PBMC_TIV_Geo", "SDY180_WholeBlood_Grp2Pneunomax23_Geo"),
+                        outputType = "summary",
+                        annotation = "latest")
   test_EM(EM, summary = TRUE)
 })
 
 test_that("loading from cache works correctly", {
+
   # Should load both matrices from cache
   expect_message(sdy$getGEMatrix(c("SDY269_PBMC_TIV_Geo", "SDY180_WholeBlood_Grp2Pneunomax23_Geo"), outputType = "summary", annotation = "latest"),
                "(cache)|(Combining ExpressionSets)", all = TRUE)
+
   # summary with a different annotation should download a new matrix
   expect_message(sdy$getGEMatrix("SDY180_WholeBlood_Grp2Pneunomax23_Geo", outputType = "summary", annotation = "default"),
                  "(Reading|Downloading)|(Constructing)", all = TRUE)
+
   # Should load eset from cache
   expect_message(sdy$getGEMatrix("SDY269_PBMC_TIV_Geo", outputType = "normalized", annotation = "latest"),
                  "Returning SDY269_PBMC_TIV_Geo_normalized_latest_eset from cache")
+
   # Should load matrix from cache and construct a new expressionset
   expect_message(sdy$getGEMatrix("SDY269_PBMC_TIV_Geo", outputType = "normalized", annotation = "default"),
                  "(Returning normalized matrix from cache)|(Downloading Features)|(Constructing ExpressionSet)", all = TRUE)
+
   # Should download a new matrix, load annotation from cache, and construct a new expressionset
   expect_message(sdy$getGEMatrix("SDY56_PBMC_Young", outputType = "normalized"),
                  "(Reading|Downloading)|(Returning latest annotation from cache)|(Constructing ExpressionSet)", all = TRUE)

--- a/tests/testthat/test-getGEMatrix.R
+++ b/tests/testthat/test-getGEMatrix.R
@@ -1,6 +1,7 @@
 context("ISCon$getGEMatrix()")
 
 # CreateConnection ------------------------------------------
+
 sdy <- CreateConnection("")
 IS1 <- CreateConnection("IS1")
 
@@ -87,13 +88,16 @@ test_that("loading from cache works correctly", {
                "(cache)|(Combining ExpressionSets)", all = TRUE)
   # summary with a different annotation should download a new matrix
   expect_message(sdy$getGEMatrix("SDY180_WholeBlood_Grp2Pneunomax23_Geo", outputType = "summary", annotation = "default"),
-                 "(Reading|Downloading)|Constructing", all = TRUE)
+                 "(Reading|Downloading)|(Constructing)", all = TRUE)
   # Should load eset from cache
-  expect_message(sdy$getGEMatrix("SDY269_PBMC_TIV_Geo", outputType = "normalized"),
-                 "returning SDY269_PBMC_TIV_Geo_normalized_latest_eset from cache")
+  expect_message(sdy$getGEMatrix("SDY269_PBMC_TIV_Geo", outputType = "normalized", annotation = "latest"),
+                 "Returning SDY269_PBMC_TIV_Geo_normalized_latest_eset from cache")
   # Should load matrix from cache and construct a new expressionset
   expect_message(sdy$getGEMatrix("SDY269_PBMC_TIV_Geo", outputType = "normalized", annotation = "default"),
-                 "(returning normalized matrix from cache)|(Downloading Features)|(Constructing ExpressionSet)", all = TRUE)
+                 "(Returning normalized matrix from cache)|(Downloading Features)|(Constructing ExpressionSet)", all = TRUE)
+  # Should download a new matrix, load annotation from cache, and construct a new expressionset
+  expect_message(sdy$getGEMatrix("SDY56_PBMC_Young", outputType = "normalized"),
+                 "(Reading|Downloading)|(Returning latest annotation from cache)|(Constructing ExpressionSet)", all = TRUE)
 })
 
 # Use specific tests here to ensure the IS1 report will load correctly

--- a/tests/testthat/test-getGEMatrix.R
+++ b/tests/testthat/test-getGEMatrix.R
@@ -79,8 +79,21 @@ test_that("get_multiple matrices summary with reload", {
 test_that("get multiple matrices summary from different studies", {
   EM <- sdy$getGEMatrix(c("SDY269_PBMC_TIV_Geo", "SDY180_WholeBlood_Grp2Pneunomax23_Geo"), outputType = "summary", annotation = "latest")
   test_EM(EM, summary = TRUE)
-  expect_equal(ncol(Biobase::exprs(EM)), 193)
-  expect_equal(nrow(Biobase::exprs(EM)), 15476)
+})
+
+test_that("loading from cache works correctly", {
+  # Should load both matrices from cache
+  expect_message(sdy$getGEMatrix(c("SDY269_PBMC_TIV_Geo", "SDY180_WholeBlood_Grp2Pneunomax23_Geo"), outputType = "summary", annotation = "latest"),
+               "(cache)|(Combining ExpressionSets)", all = TRUE)
+  # summary with a different annotation should download a new matrix
+  expect_message(sdy$getGEMatrix("SDY180_WholeBlood_Grp2Pneunomax23_Geo", outputType = "summary", annotation = "default"),
+                 "(Reading|Downloading)|Constructing", all = TRUE)
+  # Should load eset from cache
+  expect_message(sdy$getGEMatrix("SDY269_PBMC_TIV_Geo", outputType = "normalized"),
+                 "returning SDY269_PBMC_TIV_Geo_normalized_latest_eset from cache")
+  # Should load matrix from cache and construct a new expressionset
+  expect_message(sdy$getGEMatrix("SDY269_PBMC_TIV_Geo", outputType = "normalized", annotation = "default"),
+                 "(returning normalized matrix from cache)|(Downloading Features)|(Constructing ExpressionSet)", all = TRUE)
 })
 
 # Use specific tests here to ensure the IS1 report will load correctly

--- a/tests/testthat/test-getParticipantData.R
+++ b/tests/testthat/test-getParticipantData.R
@@ -27,3 +27,18 @@ test_getParticipantData("hai")
 test_getParticipantData("hla_typing")
 test_getParticipantData("elispot")
 test_getParticipantData("cohort_membership")
+
+# Test getParticipantGEMatrix()
+test_that("getParticipantGEMatrix() works correctly", {
+  skip_if_not(Sys.getenv("ISR_login") == "readonly@rglab.org")
+
+  expect_message({EM <- CONNECTIONS$ALL$getParticipantGEMatrix("gem_test")},
+                 "4 matrices found for gem_test")
+  expect_is(EM, "ExpressionSet")
+  expect_is(EM, "ExpressionSet")
+  expect_gt(ncol(Biobase::exprs(EM)), 0)
+  expect_gt(nrow(Biobase::exprs(EM)), 0)
+  # In summary, no gene is NA
+  expect_false(any(is.na(fData(EM)$gene_symbol)))
+})
+

--- a/tests/testthat/test-getParticipantData.R
+++ b/tests/testthat/test-getParticipantData.R
@@ -4,6 +4,7 @@ context("ISCon$getParticipantData()")
 # Test helpers -----------
 # Test getParticipantIdsFromGroup()
 test_that("getParticipantIdsFromGroup() works correctly", {
+  skip_if_not(Sys.getenv("ISR_login") == "readonly@rglab.org")
   ids <- CONNECTIONS$ALL$.__enclos_env__$private$.getParticipantIdsFromGroup("travis_test")
   expect_is(ids, "character")
   expect_gt(length(ids), 0)
@@ -50,7 +51,8 @@ test_getParticipantData("cohort_membership")
 
 
 test_that("listParticipantGEMatrices() works correctly", {
-  matrices <- CONNECTIONS$ALL$listParticipantGEMatrices("travis_test")
+  skip_if_not(Sys.getenv("ISR_login") == "readonly@rglab.org")
+  matrices <- CONNECTIONS$ALL$listParticipantGEMatrices("auto_test")
   expect_is(matrices, "data.table")
   expect_gt(nrow(matrices), 0)
   expect_lt(nrow(matrices), 100)
@@ -80,6 +82,6 @@ test_that("getParticipantGEMatrix() works correctly", {
   expect_lte(length(unique(EM$participant_id)), length(ids))
 
   # In summary, no gene is NA
-  expect_false(any(is.na(fData(EM)$gene_symbol)))
+  expect_false(any(is.na(Biobase::fData(EM)$gene_symbol)))
 })
 


### PR DESCRIPTION
When multiple matrix names are passed into `ISCon$getGEMatrix` they do not use cached expression sets. Creating expression sets tends to take the most time in `getGEMatrix`. Here's my attempt at changing it to use cached esets when available. I understand that there may be some side effects that I've missed and am happy to chat and/or refactor if needed. 