### PR TITLE
Fix .constructExpressionSet method

### DIFF
--- a/R/ISCon-geneExpression.R
+++ b/R/ISCon-geneExpression.R
@@ -823,9 +823,9 @@ ISCon$set(
     fasInfo <- fasInfo[ match(annoSetId, fasInfo$`Row Id`)]
     isRNA <- (fasInfo$Vendor == "NA" & !grepl("ImmSig", fasInfo$Name)) | grepl("SDY67", fasInfo$Name)
     annoVer <- ifelse(fasInfo$Comment == "Do not update" | is.na(fasInfo$Comment),
-                      annotation,
-                      strsplit(fasInfo$Comment, ":")[[1]][2]
-                      )
+      annotation,
+      strsplit(fasInfo$Comment, ":")[[1]][2]
+    )
 
     processInfo <- list(
       normalization = ifelse(isRNA, "DESeq", "normalize.quantiles"),

--- a/R/ISCon-geneExpression.R
+++ b/R/ISCon-geneExpression.R
@@ -743,8 +743,8 @@ ISCon$set(
 
     # ------ Phenotypic Data --------
     runID <- self$cache$GE_matrices[name == matrixName, rowid]
-    bs <- grep("^BS\\d{6}$", colnames(em), value = TRUE)
-    pheno_filter <- makeFilter(
+    bs <- grep("^BS\\d+$", colnames(em), value = TRUE)
+    pheno_filter <- Rlabkey::makeFilter(
       c(
         "Run",
         "EQUAL",

--- a/tests/testthat/test-getGEMatrix.R
+++ b/tests/testthat/test-getGEMatrix.R
@@ -132,6 +132,13 @@ test_that("get multiple matrices summary from different studies", {
   test_EM(EM, summary = TRUE)
 })
 
+test_that("gets SDY300 eset without error in .constructExpressionSet", {
+  EM <- ALL$getGEMatrix(
+    matrixName = "SDY300_otherCell_dcMonoFlu2011",
+  )
+  test_EM(EM, summary = TRUE)
+})
+
 test_that("loading from cache works correctly", {
 
   # Should load both matrices from cache
@@ -206,7 +213,7 @@ test_that("get ImmSig Study - SDY212 with correct anno and summary", {
   test_EM(EM, summary = FALSE)
   expect_true("BS694717.1" %in% colnames(Biobase::exprs(EM)))
   expect_true("BS694717.1" %in% Biobase::sampleNames(EM))
-  expect_true(all.equal(dim(Biobase::exprs(EM)), c(48771, 92)))
+  expect_true(all.equal(dim(Biobase::exprs(EM)), c(48770, 92)))
 })
 
 test_that("get ImmSig Study - SDY67 fixing 'X' for 'FeatureId'", {


### PR DESCRIPTION
* Ensure that method pulls feature data from cache
* Allow for longer BiosampleId length (e.g. SDY1256)
* General cleaning to be clearer and more concise
* Resulting changes affect ImmuneSignatures Rmd in LabKeyModules and vignette in package